### PR TITLE
fix(markdown-pdf) - Allow pdfMakeToPdfStreamWithCallback method of Pd…

### DIFF
--- a/packages/markdown-pdf/src/PdfTransformerBase.js
+++ b/packages/markdown-pdf/src/PdfTransformerBase.js
@@ -103,12 +103,15 @@ class PdfTransformerBase {
      */
     static pdfMakeToPdfStreamWithCallback(progressCallback) {
         return (input, outputStream) => {
-            // Default fonts are better defined at rendering time
-            input.defaultStyle = {
-                fontSize: 12,
-                font: 'LiberationSerif',
-                lineHeight: 1.5
-            };
+
+            if (!input.defaultStyle) {
+                // Default fonts are better defined at rendering time
+                input.defaultStyle = {
+                    fontSize: 12,
+                    font: 'LiberationSerif',
+                    lineHeight: 1.5
+                };
+            }
 
             // The Pdf printer
             const printer = new PdfPrinter(defaultFonts);


### PR DESCRIPTION
Signed-off-by: Shivam upadhyay <shivam.upadhyay@codinova.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Change pdfMakeToPdfStreamWithCallback to include default style only if provided input does not contains defaultStyle
### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
<img width="551" alt="Screenshot 2022-02-21 at 4 46 00 PM" src="https://user-images.githubusercontent.com/61453272/155285292-4e39c0e6-a26e-498a-b1ed-859f28006a34.png">


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`